### PR TITLE
 Added bug fix for AWS Code Build failing to zip packages with

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,6 +6,10 @@ phases:
     # Install dependencies needed for running tests
     - npm install
 
+    # Prevent files from having a timestamp before 1980
+    - find ./node_modules -mtime +10950 -exec touch {} \;
+
+
     # Upgrade AWS CLI to the latest version
     - pip install --upgrade pip
     - pip install --upgrade awscli


### PR DESCRIPTION
 modification date of 1985. Post npm install now touches files to update
 the modification date.

 Workaround sourced from: https://github.com/aws/aws-sdk-js/issues/1977

 On branch dev

 Changes to be committed:
	modified:   buildspec.yml